### PR TITLE
Fix stray closing div in map page

### DIFF
--- a/map.html
+++ b/map.html
@@ -22,7 +22,6 @@
 </head>
 <body>
   <div id="map"></div>
-  </div>
 
   <script>
     const map = new naver.maps.Map('map', {


### PR DESCRIPTION
## Summary
- remove an extraneous `</div>` from `map.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840d860e6dc8330917c8cc26e85ac63